### PR TITLE
make FormBuilder#generate_help to join error messages with model attr help text

### DIFF
--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -315,12 +315,18 @@ module BootstrapForm
     end
 
     def generate_help(name, help_text)
+      # TODO: split them, do not join. (?)
       help_text = object.errors[name].join(", ") if has_error?(name) && inline_errors
       return if help_text === false
 
-      help_text ||= get_help_text_by_i18n_key(name)
+      messages = [help_text]
+      i18n_text = get_help_text_by_i18n_key(name)
+      messages << i18n_text if i18n_text
 
-      content_tag(:span, help_text, class: 'help-block') if help_text.present?
+      messages
+        .find_all(&:present?)
+        .map { |m| content_tag(:span, m, class: 'help-block') }
+        .reduce(&:+)
     end
 
     def generate_icon(icon)


### PR DESCRIPTION
Т.к. ошибки валидации записываются на место help'ов, нам достаточно просто их заджойнить и на выходе получаем несколько спанов.