### PR TITLE
Remove deprecated `block` option for FormBuilder

### DIFF
--- a/lib/bootstrap_form/form_builder.rb
+++ b/lib/bootstrap_form/form_builder.rb
@@ -15,7 +15,7 @@ module BootstrapForm
 
     delegate :content_tag, :capture, :concat, to: :@template
 
-    def initialize(object_name, object, template, options, block = nil)
+    def initialize(object_name, object, template, options)
       @layout = options[:layout]
       @label_col = options[:label_col] || default_label_col
       @control_col = options[:control_col] || default_control_col


### PR DESCRIPTION
It does nothing in 4.0:
https://github.com/rails/rails/blob/6fffb8bb7b84a60a6c322872cc1c3560edea5b2f/actionpack/lib/action_view/helpers/form_helper.rb#L1242